### PR TITLE
履歴操作の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/core": "^7.22.1",
         "@babel/preset-env": "^7.22.2",
         "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
         "webpack": "^5.84.1",
         "webpack-cli": "^5.1.1"
       }
@@ -2582,6 +2583,15 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -2682,6 +2692,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
@@ -2704,6 +2725,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -2923,6 +2950,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2935,6 +2968,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
@@ -2942,6 +2985,27 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3026,6 +3090,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.5.0",
@@ -3505,6 +3575,18 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3553,6 +3635,44 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3570,10 +3690,22 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+      "dev": true
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "node_modules/deepmerge": {
@@ -3583,6 +3715,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3601,6 +3742,18 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3638,6 +3791,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -3683,6 +3848,37 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -3819,6 +4015,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -3860,6 +4062,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-readdir-recursive": {
@@ -4008,11 +4224,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4021,6 +4276,18 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-local": {
@@ -4168,6 +4435,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4856,6 +5129,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.5.0.tgz",
+      "integrity": "sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -5942,6 +6242,51 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6003,6 +6348,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6190,6 +6548,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
+      "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
+      "dev": true
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6212,6 +6576,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-limit": {
@@ -6281,6 +6662,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -6364,6 +6757,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -6403,6 +6805,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -6427,6 +6835,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -6548,6 +6962,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -6614,6 +7034,24 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/schema-utils": {
       "version": "3.1.2",
@@ -6844,6 +7282,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -7000,6 +7444,45 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7061,6 +7544,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -7100,6 +7592,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -7112,6 +7614,18 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/walker": {
@@ -7134,6 +7648,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/webpack": {
@@ -7259,6 +7782,40 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7279,6 +7836,15 @@
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "dev": true
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -7348,6 +7914,42 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.22.1",
     "@babel/preset-env": "^7.22.2",
     "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "webpack": "^5.84.1",
     "webpack-cli": "^5.1.1"
   }

--- a/sample/00_コア機能による単純なルーティング/index.html
+++ b/sample/00_コア機能による単純なルーティング/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script type="module">
+			import { RouteTable, Router, BrowserHistoryStorage, RouteHistory } from '../../src/routing.core.js';
+
+			const body1 = (view) => {
+				const content = document.createElement('div');
+				content.textContent = `Show '/'`;
+				const enter = () => view.appendChild(content);
+				const leave = () => view.removeChild(content);
+				return { enter, leave };
+			};
+			const body2 = (view) => {
+				const content = document.createElement('div');
+				content.textContent = `Show '/page1'`;
+				const enter = () => view.appendChild(content);
+				const leave = () => view.removeChild(content);
+				return { enter, leave };
+			};
+			const body3 = (view) => {
+				const content = document.createElement('div');
+				content.textContent = `Show '/page2'`;
+				const enter = () => view.appendChild(content);
+				const leave = () => view.removeChild(content);
+				return { enter, leave };
+			};
+
+			const observer = (from, to) => {
+				if (from) {
+					for (const { route, router } of from) {
+						route.body.leave();
+					}
+				}
+				if (to) {
+					for (const { route, router } of to) {
+						route.body.enter();
+					}
+				}
+			};
+
+			const view = document.getElementById('view');
+			const routes = [
+				{ path: '/', body: body1(view) },
+				{ path: '/page1', body: body2(view) },
+				{ path: '/page2', body: body3(view) },
+			];
+			const routeTable = new RouteTable(routes);
+			const storage = new BrowserHistoryStorage(window.history, route => `#${route.path ?? route.name ?? route}`);
+			const router = new RouteHistory(
+				new Router(routeTable, router => {}),
+				storage, observer, observer, observer
+			);
+
+			window.addEventListener('popstate', e => {
+				const state = e.state;
+				if (state) {
+					// 「戻る」や「進む」のブラウザのイベントを通知する
+					router.notify(state);
+				}
+			});
+			window.addEventListener('DOMContentLoaded', e => {
+				// 初期状態の表示する要素の決定
+				router.replace(window.location.hash.length === 0 ? '/' : window.location.hash.substr(1));
+			});
+
+			// 遷移イベントの設置
+			document.getElementById('route-list').querySelectorAll('*[data-to]').forEach(e => {
+				e.addEventListener('click', () => router.push(e.dataset.to));
+			});
+		</script>
+	</head>
+	<body>
+		<ul id="route-list">
+			<li data-to="/">Routeの表示</li>
+			<li data-to="/page1">Page1の表示</li>
+			<li data-to="/page2">Page2の表示</li>
+		</ul>
+		<div id="view"></div>
+	</body>
+</html>

--- a/src/history-storage.js
+++ b/src/history-storage.js
@@ -1,0 +1,236 @@
+/**
+ * @template T
+ * @typedef { import("./route-table.js").Route<T> } Route ルート情報
+ */
+
+/**
+ * @template T
+ * @typedef { { id: number; route: (string | Route<T>)? } } RouteHistoryState 履歴操作のためのルートの状態
+ */
+
+/**
+ * 履歴のストレージのインターフェース
+ * @template T
+ * @interface
+ */
+/* istanbul ignore next */
+class IHistoryStorage {
+	/**
+	 * 履歴にルートを追加する
+	 * @param { string | Route<T> } route 履歴に追加するルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	push(route) { throw new Error('not implemented.'); }
+	/**
+	 * 履歴にルートを置き換える
+	 * @param { string | Route<T> } route 履歴に置き換えるルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	replace(route) { throw new Error('not implemented.'); }
+	/**
+	 * 現在位置を起点とした履歴の移動
+	 * @param { number } delta 移動先の相対位置
+	 * @returns { Promise<RouteHistoryState<T>> } 移動先のルート
+	 */
+	go(delta) { throw new Error('not implemented.'); }
+
+	/**
+	 * カレントの取得
+	 * @returns { RouteHistoryState<T> } カレントのルート
+	 */
+	get state() { throw new Error('not implemented.'); }
+}
+
+/**
+ * History APIによる履歴のストレージ
+ * @template T
+ * @implements { IHistoryStorage<T> }
+ */
+class BrowserHistoryStorage {
+	/**
+	 * @type { History } 履歴情報
+	 */
+	#history;
+	/**
+	 * @type { (route: string | Route<T>) => string | URL } ルート情報からHistory APIで利用するURLを生成する関数
+	 */
+	#makeUrl;
+	/**
+	 * @type { number } 履歴情報のカレントポジション
+	 */
+	#currentPos = 0;
+	/**
+	 * @type { number } 履歴の長さ
+	 */
+	#length = 0;
+	/**
+	 * @type { { id: number; resolve: (value: RouteHistoryState<T>) => void }[] } go()の解決を管理するキュー
+	 */
+	#stateQueue = [];
+	/**
+	 * @type { number } go()におけるタイムアウトまでのミリ秒
+	 */
+	timeout;
+
+	/**
+	 * History APIによる履歴のストレージの初期化
+	 * @param { History } history 履歴情報
+	 * @param { (route: string | Route<T>) => string } makeUrl ルート情報からHistory APIで利用するURLを生成する関数
+	 */
+	constructor(history, makeUrl = route => `${route.path ?? route.name ?? route}`, timeout = 100) {
+		this.#history = history;
+		this.#makeUrl = makeUrl;
+		// 既に存在する履歴の引継ぎ
+		if (Number.isInteger(this.#history.state?.id)) {
+			this.#currentPos = this.#history.state.id;
+		}
+		else {
+			this.#history.replaceState({ id: 0, route: null }, '');
+		}
+		this.#length = this.#currentPos + 1;
+		this.timeout = timeout;
+		// go()についてのキューの管理
+		window.addEventListener('popstate', e => {
+			const state = e.state;
+			if (state && this.#stateQueue.length > 0 && state?.id === this.#stateQueue[0].id) {
+				// キューをポップして解決済みにする
+				const { id, resolve } = this.#stateQueue.shift();
+				resolve(state);
+			}
+		});
+	}
+
+	/**
+	 * 履歴にルートを追加する
+	 * @param { string | Route<T> } route 履歴に追加するルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	push(route) {
+		++this.#currentPos;
+		this.#length = this.#currentPos + 1;
+		this.#history.pushState({ id: this.#currentPos, route }, '', this.#makeUrl(route));
+		return this.state;
+	}
+	/**
+	 * 履歴にルートを置き換える
+	 * @param { string | Route<T> } route 履歴に置き換えるルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	replace(route) {
+		this.#history.replaceState({ id: this.#currentPos, route }, '', this.#makeUrl(route));
+		return this.state;
+	}
+	/**
+	 * 現在位置を起点とした履歴の移動
+	 * @param { number } delta 移動先の相対位置
+	 * @returns { Promise<RouteHistoryState<T>> } 移動先のルート
+	 */
+	go(delta) {
+		// go()についてのタスクのpushする
+		let state = null;
+		const stateElement = {
+			// clamp
+			id: Math.max(0, Math.min(this.#currentPos + delta, this.#length - 1)),
+			resolve: /* istanbul ignore next */value => { state = value; }
+		};
+		const realDelta = stateElement.id - this.#currentPos;
+		this.#stateQueue.push(stateElement);
+
+		if (delta === 0 || realDelta !== 0) {
+			// clampした範囲で移動をする
+			this.#history.go(realDelta);
+		}
+		else {
+			// 移動の必要がない場合はキューを元に戻してから終了させる
+			this.#stateQueue.pop();
+			return Promise.resolve(this.state);
+		}
+
+		let timeoutID  = null;
+		return new Promise((resolve, reject) => {
+			stateElement.resolve = resolve;
+			/* istanbul ignore next */
+			if (state) {
+				// Promiseのresolve設定時点でpopstateで解決していた場合は即解決とする
+				resolve(state);
+			}
+			timeoutID = setTimeout(() => {
+				// タイムアウト
+				reject(new Error('timeout'));
+			}, this.timeout);
+		}).then(response => {
+			// タイマーを中止する
+			/* istanbul ignore next */
+			if (timeoutID) {
+				clearTimeout(timeoutID);
+			}
+			this.#currentPos = response.id;
+			return response;
+		});
+	}
+
+	/**
+	 * カレントの取得
+	 * @returns { RouteHistoryState<T> } カレントのルート
+	 */
+	get state() {
+		return this.#history.state;
+	}
+}
+
+/**
+ * メモリ上で管理する履歴のストレージ
+ * @template T
+ * @implements { IHistoryStorage<T> }
+ */
+class MemoryHistoryStorage {
+	/**
+	 * @type { RouteHistoryState<T>[] } 履歴情報
+	 */
+	#historyStack = [{ id: 0, route: null }];
+	/**
+	 * @type { number } 履歴情報のカレントポジション
+	 */
+	#currentPos = 0;
+
+	/**
+	 * 履歴にルートを追加する
+	 * @param { string | Route<T> } route 履歴に追加するルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	push(route) {
+		// this.#currentPos以降の要素を削除して挿入
+		++this.#currentPos;
+		this.#historyStack.splice(this.#currentPos, this.#historyStack.length, { id: this.#currentPos, route });
+		return this.state;
+	}
+	/**
+	 * 履歴にルートを置き換える
+	 * @param { string | Route<T> } route 履歴に置き換えるルート情報
+	 * @returns { RouteHistoryState<T> } 移動先のルート
+	 */
+	replace(route) {
+		this.#historyStack.splice(this.#currentPos, 1, { id: this.#currentPos, route });
+		return this.state;
+	}
+	/**
+	 * 現在位置を起点とした履歴の移動
+	 * @param { number } delta 移動先の相対位置
+	 * @returns { Promise<RouteHistoryState<T>> } 移動先のルート
+	 */
+	go(delta) {
+		// clamp
+		this.#currentPos = Math.max(0, Math.min(this.#currentPos + delta, this.#historyStack.length - 1));
+		return  Promise.resolve(this.state);
+	}
+
+	/**
+	 * カレントの取得
+	 * @returns { RouteHistoryState<T> } カレントのルート
+	 */
+	get state() {
+		return this.#historyStack[this.#currentPos];
+	}
+}
+
+export { IHistoryStorage, BrowserHistoryStorage, MemoryHistoryStorage };

--- a/src/history.js
+++ b/src/history.js
@@ -1,0 +1,183 @@
+import { IRouter } from "./router.js";
+import { IHistoryStorage } from "./history-storage.js"
+
+/**
+ * @template T
+ * @typedef { import("./route-table.js").Route<T> } Route ルート情報
+ */
+
+/**
+ * @template T
+ * @typedef { import("./router.js").TraceRoute<T> } TraceRoute ルート解決の経路
+ */
+
+/**
+ * @template T
+ * @typedef { import("./history-storage.js").RouteHistoryState<T> } RouteHistoryState 履歴操作のためのルートの状態
+ */
+
+/**
+ * @template T, R
+ * @typedef { (from: Readonly<TraceRoute<T>>?, to: Readonly<TraceRoute<T>>) => R } PushHistoryObserver 履歴に対してpush()した際に呼び出すオブザーバ
+ */
+
+/**
+ * @template T, R
+ * @typedef { (from: Readonly<TraceRoute<T>>?, to: Readonly<TraceRoute<T>>) => R } ReplaceHistoryObserver 履歴に対してreplace()した際に呼び出すオブザーバ
+ */
+
+/**
+ * @template T, R
+ * @typedef { (from: Readonly<TraceRoute<T>>?, to: Readonly<TraceRoute<T>>?, delta: number, realDelta: number) => R } GoHistoryObserver 履歴に対してgo()した際に呼び出すオブザーバ
+ */
+
+
+/**
+ * 履歴操作クラス
+ * @template T, R1, R2, R3
+ * @implements { IRouter<T> }
+ */
+class RouteHistory {
+	/**
+	 * @type { IRouter<T> } ルータ
+	 */
+	#router;
+	/**
+	 * @type { IHistoryStorage<T> } 履歴を管理するストレージ
+	 */
+	#strage;
+	/**
+	 * @type { TraceRoute<T>? } 現在のルート情報についての経路
+	 */
+	#currentTraceRoute = null;
+	/**
+	 * @type { RouteHistoryState<T> } 現在のルート情報についての経路
+	 */
+	#routeHistoryState;
+	/**
+	 * @type { PushHistoryObserver<T, R1> } 履歴に対してpush()した際に呼び出すオブザーバ
+	 */
+	#pushHistoryObserver;
+	/**
+	 * @type { ReplaceHistoryObserver<T, R2> } 履歴に対してreplace()した際に呼び出すオブザーバ
+	 */
+	#replaceHistoryObserver;
+	/**
+	 * @type { GoHistoryObserver<T, R3> } 履歴に対してgo()した際に呼び出すオブザーバ
+	 */
+	#goHistoryObserver;
+
+	/**
+	 * 履歴操作クラスの初期化
+	 * @param { IRouter<T> } router ルータ
+	 * @param { IHistoryStorage<T> } strage 履歴を管理するストレージ
+	 * @param { PushHistoryObserver<T, R1> } 履歴に対してpush()した際に呼び出すオブザーバ
+	 * @param { ReplaceHistoryObserver<T, R2> } 履歴に対してreplace()した際に呼び出すオブザーバ
+	 * @param { GoHistoryObserver<T, R2> } 履歴に対してgo()した際に呼び出すオブザーバ
+	 */
+	constructor(router, strage, pushHistoryObserver, replaceHistoryObserver, goHistoryObserver) {
+		this.#router = router;
+		this.#strage = strage;
+		this.#routeHistoryState = this.#strage.state;
+		this.#pushHistoryObserver = pushHistoryObserver;
+		this.#replaceHistoryObserver = replaceHistoryObserver;
+		this.#goHistoryObserver = goHistoryObserver;
+	}
+
+	/**
+	 * 履歴にルートを追加する
+	 * @param { string | Route<T> } route 履歴に追加するルート情報
+	 * @returns { R1 }
+	 */
+	push(route) {
+		const to = this.routing(route);
+		const from = this.#currentTraceRoute;
+		this.#routeHistoryState = this.#strage.push(route);
+		this.#currentTraceRoute = to;
+		return this.#pushHistoryObserver(from, to);
+	}
+	/**
+	 * 履歴にルートを置き換える
+	 * @param { string | Route<T> } route 履歴に置き換えるルート情報
+	 * @returns { R2 }
+	 */
+	replace(route) {
+		const to = this.routing(route);
+		const from = this.#currentTraceRoute;
+		this.#routeHistoryState = this.#strage.replace(route);
+		this.#currentTraceRoute = to;
+		return this.#replaceHistoryObserver(from, to);
+	}
+	/**
+	 * 現在位置を起点とした履歴の移動
+	 * @param { number } delta 移動先の相対位置
+	 * @returns { Promise<R3> }
+	 */
+	go(delta) {
+		return this.#strage.go(delta).then(state => {
+			const realDelta = state.id - this.#routeHistoryState.id;
+			this.#routeHistoryState = state;
+			if (state.route !== null) {
+				const to = this.routing(state.route);
+				const from = this.#currentTraceRoute;
+				this.#currentTraceRoute = to;
+				return this.#goHistoryObserver(from, to, delta, realDelta);
+			}
+			else {
+				// ルート情報がないときはそのままオブザーバへ渡す
+				const from = this.#currentTraceRoute;
+				this.#currentTraceRoute = null;
+				return this.#goHistoryObserver(from, null, delta, realDelta);
+			}
+		});
+	}
+	/**
+	 * 現在位置を起点とした直前の履歴へ移動
+	 * @returns { Promise<R3> }
+	 */
+	back() {
+		return this.go(-1);
+	}
+	/**
+	 * 現在位置を起点とした直後の履歴へ移動
+	 * @returns { Promise<R3> }
+	 */
+	forward() {
+		return this.go(1);
+	}
+
+	/**
+	 * 外部からのストレージの変更を通知(pushやreplaceの検知は実施しない)
+	 * @returns { Promise<R3>? }
+	 */
+	notify() {
+		const delta = this.#strage.state.id - this.#routeHistoryState.id;
+		if (delta !== 0) {
+			this.#routeHistoryState = this.#strage.state;
+			if (this.#strage.state.route !== null) {
+				const to = this.#router.routing(this.#strage.state.route);
+				const from = this.#currentTraceRoute;
+				this.#currentTraceRoute = to;
+				return this.#goHistoryObserver(from, to, delta, delta);
+			}
+			else {
+				const from = this.#currentTraceRoute;
+				this.#currentTraceRoute = null;
+				return this.#goHistoryObserver(from, null, delta, delta);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * ルーティングの実施
+	 * @param { string | Route<T> } route 遷移先のルート情報
+	 * @param {  Readonly<TraceRoute<T>> } trace 現時点でのルート解決の経路
+	 * @return { TraceRoute<T> } ルート解決の経路
+	 */
+	routing(route, trace = []) {
+		return this.#router.routing(route, trace);
+	}
+}
+
+export { RouteHistory };

--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,7 @@ import { IRouteTable } from "./route-table.js";
 
 /**
  * @template T
- * @typedef { { router: IRouter<T>; route?: Route<T>; }[] } TraceRoute ルート解決の経路
+ * @typedef { { router: IRouter<T>; route?: string | Route<T>; }[] } TraceRoute ルート解決の経路
  */
 
 /**

--- a/src/router.js
+++ b/src/router.js
@@ -1,18 +1,40 @@
-import { IRouteTable } from "./route-table";
+import { IRouteTable } from "./route-table.js";
 
 /**
  * @template T
- * @typedef { import("./route-table").Route<T> } Route ルート情報
+ * @typedef { import("./route-table.js").Route<T> } Route ルート情報
  */
 
 /**
  * @template T
- * @typedef { (route: Route<T>) => boolean | Route<T> } RouterObserver ルート遷移に関するオブザーバ
+ * @typedef { (route: Route<T>, trace: Readonly<TraceRoute<T>>) => TraceRoute<T> | Route<T> | undefined | null } RouterObserver ルート解決に関するオブザーバ
  */
+
+/**
+ * @template T
+ * @typedef { { router: IRouter<T>; route?: Route<T>; }[] } TraceRoute ルート解決の経路
+ */
+
+/**
+ * ルータのインターフェース
+ * @template T
+ * @interface
+ */
+/* istanbul ignore next */
+class IRouter {
+	/**
+	 * ルーティングの実施
+	 * @param { string | Route<T> } route 遷移先のルート情報
+	 * @param { Readonly<TraceRoute<T>> } trace 現時点でのルート解決の経路
+	 * @return { TraceRoute<T> } ルート解決の経路
+	 */
+	routing(route, trace = []) { throw new Error('not implemented.'); }
+}
 
 /**
  * ルータクラス
  * @template T
+ * @implements { IRouter<T> }
  */
 class Router {
 	/**
@@ -28,28 +50,25 @@ class Router {
 	 * ルータの初期化
 	 * @param { IRouteTable<T> } routeTable 初期状態のルート情報
 	 * @param { RouterObserver<T> } observer ルーティングの通知を受け取るオブザーバ
-	 * @param { (string | Route<T>)? } defaultRoute 初期状態のルート
 	 */
-	constructor(routeTable, observer, defaultRoute = '/') {
+	constructor(routeTable, observer) {
 		this.#routeTable = routeTable;
 		this.#observer = observer;
-		if (defaultRoute !== null) {
-			this.routing(defaultRoute);
-		}
 	}
 
 	/**
 	 * ルーティングの実施
 	 * @param { string | Route<T> } route 遷移先のルート情報
-	 * @return { boolean } trueならルーティング成功、falseならルーティング失敗
+	 * @param {  Readonly<TraceRoute<T>> } trace 現時点でのルート解決の経路
+	 * @return { TraceRoute<T> } ルート解決の経路
 	 */
-	routing(route) {
+	routing(route, trace = []) {
 		// restが存在する場合はrestをpathとして取得
 		const r = this.#routeTable.get(route?.segment === true && 'rest' in route ? { path: route.rest } : route);
 		const path = typeof route === 'string' ? route : route.path;
 		const name = typeof route === 'string' ? undefined : route.name;
 		if (r === undefined) {
-			throw new Error(`The requested Route-Path '${path}' or Route-Name '${name}' was not found`);
+			return [ ...trace, { router: this } ];
 		}
 		const ret = this.#observer(new Proxy(r, {
 			// 解決済みのpathを返すようにするかつ変更不可にする
@@ -63,10 +82,15 @@ class Router {
 				}
 				return Reflect.set(...arguments);
 			}
-		}));
-		return (ret === true || ret === false) ? ret :
-				(ret === undefined || ret === null) ? true : this.routing(ret);
+		}), []);
+		if (Array.isArray(ret)) {
+			return [ ...trace, { router: this, route: r }, ...ret ];
+		}
+		if (ret === undefined || ret === null) {
+			return [ ...trace, { router: this, route: r } ];
+		}
+		return this.routing(ret, trace);
 	}
 }
 
-export { Router };
+export { Router, IRouter };

--- a/src/routing.core.js
+++ b/src/routing.core.js
@@ -1,0 +1,5 @@
+// moduleを集約
+export * from './history-storage.js';
+export * from './history.js';
+export * from './route-table.js';
+export * from './router.js';

--- a/tests/integration/router.test.js
+++ b/tests/integration/router.test.js
@@ -14,9 +14,9 @@ import { jest } from '@jest/globals'
  */
 
 describe('Router', () => {
-	/** @type { jest.Mock<(route: Route<T>) => boolean> } ルーティング通知を受け取るオブザーバのモック  */
-	const mockObserver = jest.fn(route => true);
-	/** @type { jest.Mock<(route: Route<T>) => unknown> } ルートのボディのモック  */
+	/** @type { jest.Mock<RouterObserver<T>> } ルーティング通知を受け取るオブザーバのモック  */
+	const mockObserver = jest.fn(route => {});
+	/** @type { jest.Mock<RouterObserver<T>> } ルートのボディのモック  */
 	const mockBody = jest.fn(route => {});
 
 	beforeEach(() => {
@@ -31,54 +31,67 @@ describe('Router', () => {
 				{ path: '/:page', body: '/:page' }
 			]);
 			const router = new Router(routeTable, mockObserver);
-			expect(router.routing('/param')).toBe(true);
-			expect(mockObserver.mock.calls[1][0].body).toBe('/:page');
+			expect(router.routing('/param').length).toBe(1);
+			expect(mockObserver.mock.calls[0][0].body).toBe('/:page');
 			// pathにはrouting()に渡したpathが設定される
-			expect(mockObserver.mock.calls[1][0].path).toBe('/param');
+			expect(mockObserver.mock.calls[0][0].path).toBe('/param');
 		});
 
 		it('複数のルータの結合', () => {
-			/**
-			 * @typedef { Route<(route: MyRoute) => unknown> } MyRoute ルート解決のためのツリー
-			 */
-
-			/** @type { RouteTable<(route: MyRoute) => unknown> } メインのルートテーブル */
+			/** @type { RouteTable<RouterObserver<T>> } メインのルートテーブル */
 			const routeTable = new RouteTable([
 				{ path: '/', body: mockBody },
 				{ path: '/page1', segment: true },
 				{ path: '/page1/page1-1', body: mockBody }
 			]);
-			/** @type { Router<(route: MyRoute) => unknown> } メインのルータ */
-			const router = new Router(routeTable, route => route.body(route));
+			/** @type { Router<RouterObserver<T>> } メインのルータ */
+			const router = new Router(routeTable, (route, trace) => route.body(route, trace));
 
-			/** @type { RouteTable<(route: MyRoute) => unknown> } 分散して管理するルートテーブル */
+			/** @type { RouteTable<RouterObserver<T>> } 分散して管理するルートテーブル */
 			const subRouteTable = new RouteTable([
 				{ path: '/', body: mockBody },
 				{ path: '/page1-1', body: mockBody },
 				{ path: '/page1-2', body: mockBody }
 			]);
-			/** @type { Router<(route: MyRoute) => unknown> } 分散して管理するルータ */
-			const subrouter = new Router(subRouteTable, route => route.body(route), null);
+			/** @type { Router<RouterObserver<T>> } 分散して管理するルータ */
+			const subrouter = new Router(subRouteTable, (route, trace) => route.body(route, trace));
 
-			routeTable.get('/page1').body = route => {
+			routeTable.get('/page1').body = (route, trace) => {
 				mockBody(route);
 				// 別のルータでルーティングする
-				subrouter.routing(route);
+				return subrouter.routing(route, trace);
 			};
 
 			// subRouteTableの'/page1-2'へマッチングする
-			router.routing('/page1/page1-2');
+			const traceRoute1 = router.routing('/page1/page1-2');
+			expect(traceRoute1.length).toBe(2);
+			expect('route' in traceRoute1[0]).toBe(true);
+			expect('route' in traceRoute1[1]).toBe(true);
+			expect(traceRoute1[0].router).toBe(router);
+			expect(traceRoute1[1].router).toBe(subrouter);
+			expect(mockBody.mock.calls[0][0].path).toBe('/page1/page1-2');
+			expect(mockBody.mock.calls[0][0].rest).toBe('page1-2');
 			expect(mockBody.mock.calls[1][0].path).toBe('/page1/page1-2');
-			expect(mockBody.mock.calls[1][0].rest).toBe('page1-2');
-			expect(mockBody.mock.calls[2][0].path).toBe('/page1/page1-2');
+			expect(mockBody.mock.calls[1][0].rest).toBe(undefined);
+			expect(mockBody.mock.calls).toHaveLength(2);
+			// subRouteTableの'/page1-1'へではなくrouteTableの'/page1/page1-1'へマッチングする
+			const traceRoute2 = router.routing('/page1/page1-1');
+			expect(traceRoute2.length).toBe(1);
+			expect('route' in traceRoute2[0]).toBe(true);
+			expect(traceRoute2[0].router).toBe(router);
+			expect(mockBody.mock.calls[2][0].path).toBe('/page1/page1-1');
 			expect(mockBody.mock.calls[2][0].rest).toBe(undefined);
 			expect(mockBody.mock.calls).toHaveLength(3);
-			// subRouteTableの'/page1-1'へではなくrouteTableの'/page1/page1-1'へマッチングする
-			router.routing('/page1/page1-1');
-			expect(mockBody.mock.calls[3][0].path).toBe('/page1/page1-1');
-			expect(mockBody.mock.calls[3][0].rest).toBe(undefined);
+			// subRouteTableでマッチングを試みるが失敗する
+			const traceRoute3 = router.routing('/page1/page1-3');
+			expect(traceRoute3.length).toBe(2);
+			expect('route' in traceRoute3[0]).toBe(true);
+			expect('route' in traceRoute3[1]).toBe(false);
+			expect(traceRoute3[0].router).toBe(router);
+			expect(traceRoute3[1].router).toBe(subrouter);
+			expect(mockBody.mock.calls[3][0].path).toBe('/page1/page1-3');
+			expect(mockBody.mock.calls[3][0].rest).toBe('page1-3');
 			expect(mockBody.mock.calls).toHaveLength(4);
-
 		});
 	});
 

--- a/tests/unit/history-storage.test.js
+++ b/tests/unit/history-storage.test.js
@@ -1,0 +1,107 @@
+/** @jest-environment jsdom */
+import { BrowserHistoryStorage, MemoryHistoryStorage } from '../../src/history-storage.js';
+
+/**
+ * @template T
+ * @typedef { import("../../src/route-table.js").Route<T> } Route ルート情報
+ */
+
+describe('BrowserHistoryStorage', () => {
+	beforeEach(() => {
+		window.history.replaceState(null, '', '/');
+	});
+
+	it('履歴のスタック操作の確認', async () => {
+		// 初期状態のスタック
+		const storage = new BrowserHistoryStorage(window.history);
+		expect(storage.state.id).toBe(0);
+		expect(storage.state.route).toBe(null);
+		// 履歴の追加
+		expect(storage.push('/path1')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path1');
+		expect(storage.push('/path2')).toEqual(storage.state);
+		expect(storage.state.id).toBe(2);
+		expect(storage.state.route).toBe('/path2');
+		// 履歴の置換と追加
+		expect(storage.replace('/path3')).toEqual(storage.state);
+		expect(storage.state.id).toBe(2);
+		expect(storage.state.route).toBe('/path3');
+		expect(storage.push('/path4')).toEqual(storage.state);
+		expect(storage.state.id).toBe(3);
+		expect(storage.state.route).toBe('/path4');
+		// 履歴の移動と置換
+		expect(await storage.go(-2)).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path1');
+		expect(storage.replace('/path5')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path5');
+		// 履歴の最大量の移動
+		expect(await storage.go(100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(3);
+		expect(storage.state.route).toBe('/path4');
+		// 履歴の最大量の移動と追加
+		expect(await storage.go(-100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(0);
+		expect(storage.state.route).toBe(null);
+		expect(storage.push('/path6')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path6');
+		expect(await storage.go(100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path6');
+		// 履歴情報の引継ぎ
+		const storage2 = new BrowserHistoryStorage(window.history);
+		expect(storage2.state.id).toBe(1);
+		expect(storage2.state.route).toBe('/path6');
+		// 外部から履歴を挿入して整合性を失わせる
+		window.history.replaceState(null, '', '/page7');
+		expect(await storage2.go(-1)).toEqual(storage2.state);
+		await expect(async () => await storage2.go(1)).rejects.toThrow();
+	});
+});
+
+describe('MemoryHistoryStorage', () => {
+	it('履歴のスタック操作の確認', async () => {
+		// 初期状態のスタック
+		const storage = new MemoryHistoryStorage();
+		expect(storage.state.id).toBe(0);
+		expect(storage.state.route).toBe(null);
+		// 履歴の追加
+		expect(storage.push('/path1')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path1');
+		expect(storage.push('/path2')).toEqual(storage.state);
+		expect(storage.state.id).toBe(2);
+		expect(storage.state.route).toBe('/path2');
+		// 履歴の置換と追加
+		expect(storage.replace('/path3')).toEqual(storage.state);
+		expect(storage.state.id).toBe(2);
+		expect(storage.state.route).toBe('/path3');
+		expect(storage.push('/path4')).toEqual(storage.state);
+		expect(storage.state.id).toBe(3);
+		expect(storage.state.route).toBe('/path4');
+		// 履歴の移動と置換
+		expect(await storage.go(-2)).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path1');
+		expect(storage.replace('/path5')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path5');
+		// 履歴の最大量の移動
+		expect(await storage.go(100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(3);
+		expect(storage.state.route).toBe('/path4');
+		// 履歴の最大量の移動と追加
+		expect(await storage.go(-100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(0);
+		expect(storage.state.route).toBe(null);
+		expect(storage.push('/path6')).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path6');
+		expect(await storage.go(100)).toEqual(storage.state);
+		expect(storage.state.id).toBe(1);
+		expect(storage.state.route).toBe('/path6');
+	});
+});

--- a/tests/unit/history.test.js
+++ b/tests/unit/history.test.js
@@ -1,0 +1,194 @@
+import { IRouter } from "../../src/router.js";
+import { MemoryHistoryStorage } from '../../src/history-storage.js';
+import { RouteHistory } from '../../src/history.js';
+import { jest } from '@jest/globals'
+
+/**
+ * @template T
+ * @typedef { import("../../src/route-table.js").Route<T> } Route ルート情報
+ */
+
+/**
+ * @template T, R
+ * @typedef { import("../../src/history.js").PushHistoryObserver<T, R> } PushHistoryObserver 履歴に対してpush()した際に呼び出すオブザーバ
+ */
+
+/**
+ * @template T, R
+ * @typedef { import("../../src/history.js").ReplaceHistoryObserver<T, R> } ReplaceHistoryObserver 履歴に対してreplace()した際に呼び出すオブザーバ
+ */
+
+/**
+ * @template T, R
+ * @typedef { import("../../src/history.js").GoHistoryObserver<T, R> } GoHistoryObserver 履歴に対してgo()した際に呼び出すオブザーバ
+ */
+
+/**
+ * ルータのスタブ
+ * @template T
+ * @implements { IRouter<T> }
+ */
+class StubRouter {
+	/**
+	 * ルーティングの実施
+	 * @param { string | Route<T> } route 遷移先のルート情報
+	 * @param {  Readonly<TraceRoute<T>> } trace 現時点でのルート解決の経路
+	 * @return { TraceRoute<T> } ルート解決の経路
+	 */
+	routing(route, trace = []) {
+		return [ ...trace, { router: this, route } ];
+	}
+}
+
+describe('RouteHistory', () => {
+	/** @type { jest.Mock<PushHistoryObserver<T, R>> } 履歴に対してpush()した際に呼び出すオブザーバのモック  */
+	const mockPushObserver = jest.fn((from, to) => 1);
+	/** @type { jest.Mock<ReplaceHistoryObserver<T, R>> } 履歴に対してreplace()した際に呼び出すオブザーバのモック  */
+	const mockReplaceObserver = jest.fn((from, to) => 2);
+	/** @type { jest.Mock<GoHistoryObserver<T, R>> } 履歴に対してgo()した際に呼び出すオブザーバのモック  */
+	const mockGoObserver = jest.fn((from, to, delta, realDelta) => 3);
+
+	beforeEach(() => {
+		mockPushObserver.mockClear();
+		mockReplaceObserver.mockClear();
+		mockGoObserver.mockClear();
+	});
+
+	describe('RouteHistory.push()', () => {
+		it('push操作の確認', () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(router.push('/page1')).toBe(1);
+			expect(mockPushObserver.mock.calls[0][0]).toBe(null);
+			expect(mockPushObserver.mock.calls[0][1][0].route).toBe('/page1');
+			expect(mockPushObserver.mock.calls).toHaveLength(1);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls).toHaveLength(0);
+		});
+	});
+
+	describe('RouteHistory.replace()', () => {
+		it('replace操作の確認', () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(router.replace('/page1')).toBe(2);
+			expect(mockPushObserver.mock.calls).toHaveLength(0);
+			expect(mockReplaceObserver.mock.calls[0][0]).toBe(null);
+			expect(mockReplaceObserver.mock.calls[0][1][0].route).toBe('/page1');
+			expect(mockReplaceObserver.mock.calls).toHaveLength(1);
+			expect(mockGoObserver.mock.calls).toHaveLength(0);
+		});
+	});
+
+	describe('RouteHistory.forward()', () => {
+		it('遷移先が存在しない場合の動作', async () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(await router.forward()).toBe(3);
+			expect(mockPushObserver.mock.calls).toHaveLength(0);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls[0][0]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][1]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][2]).toBe(1);
+			expect(mockGoObserver.mock.calls[0][3]).toBe(0);
+			expect(mockGoObserver.mock.calls).toHaveLength(1);
+		});
+
+		it('遷移先が存在する場合の動作', async () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(router.push('/page1')).toBe(1);
+			expect(await router.back()).toBe(3);
+			expect(await router.forward()).toBe(3);
+			expect(mockPushObserver.mock.calls).toHaveLength(1);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls[0][0][0].route).toBe('/page1');
+			expect(mockGoObserver.mock.calls[0][1]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][2]).toBe(-1);
+			expect(mockGoObserver.mock.calls[0][3]).toBe(-1);
+			expect(mockGoObserver.mock.calls[1][0]).toBe(null);
+			expect(mockGoObserver.mock.calls[1][1][0].route).toBe('/page1');
+			expect(mockGoObserver.mock.calls[1][2]).toBe(1);
+			expect(mockGoObserver.mock.calls[1][3]).toBe(1);
+			expect(mockGoObserver.mock.calls).toHaveLength(2);
+		});
+	});
+
+	describe('RouteHistory.back()', () => {
+		it('遷移先が存在しない場合の動作', async () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(await router.back()).toBe(3);
+			expect(mockPushObserver.mock.calls).toHaveLength(0);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls[0][0]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][1]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][2]).toBe(-1);
+			expect(mockGoObserver.mock.calls[0][3]).toBe(0);
+			expect(mockGoObserver.mock.calls).toHaveLength(1);
+		});
+	});
+
+	describe('RouteHistory.notify()', () => {
+		it('無効な通知の場合の動作', async () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(await router.notify()).toBe(null);
+			expect(mockPushObserver.mock.calls).toHaveLength(0);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls).toHaveLength(0);
+		});
+
+		it('有効な通知の場合の動作', async () => {
+			const storage = new MemoryHistoryStorage();
+			const router = new RouteHistory(
+				new StubRouter(),
+				storage, mockPushObserver, mockReplaceObserver, mockGoObserver
+			);
+
+			expect(router.push('/page1')).toBe(1);
+
+			// 仮想的に「戻る」を実施
+			await storage.go(-1);
+			expect(await router.notify()).toBe(3);
+			// 仮想的に「進む」を実施
+			await storage.go(1);
+			expect(await router.notify()).toBe(3);
+			expect(mockPushObserver.mock.calls).toHaveLength(1);
+			expect(mockReplaceObserver.mock.calls).toHaveLength(0);
+			expect(mockGoObserver.mock.calls[0][0][0].route).toBe('/page1');
+			expect(mockGoObserver.mock.calls[0][1]).toBe(null);
+			expect(mockGoObserver.mock.calls[0][2]).toBe(-1);
+			expect(mockGoObserver.mock.calls[0][3]).toBe(-1);
+			expect(mockGoObserver.mock.calls[1][0]).toBe(null);
+			expect(mockGoObserver.mock.calls[1][1][0].route).toBe('/page1');
+			expect(mockGoObserver.mock.calls[1][2]).toBe(1);
+			expect(mockGoObserver.mock.calls[1][3]).toBe(1);
+			expect(mockGoObserver.mock.calls).toHaveLength(2);
+		});
+	});	
+});


### PR DESCRIPTION
履歴操作の実装にあたり、以下の点を変更・追加。

- ルータのインターフェース`IRouter`の追加
- `IRouter.routing()`がルーティングの成功の可否ではなくルーティングの経路を返すように変更
- 履歴のストレージクラス`BrowserHistoryStorage`と`MemoryHistoryStorage`の追加
- 履歴操作クラス`RouteHistory`の追加
- サンプルを"sample/00_コア機能による単純なルーティング"に追加