### PR TITLE
追加したサンプルの`notify()`に余計な引数が混在していたためそれの除去

### DIFF
--- a/sample/00_コア機能による単純なルーティング/index.html
+++ b/sample/00_コア機能による単純なルーティング/index.html
@@ -56,7 +56,7 @@
 				const state = e.state;
 				if (state) {
 					// 「戻る」や「進む」のブラウザのイベントを通知する
-					router.notify(state);
+					router.notify();
 				}
 			});
 			window.addEventListener('DOMContentLoaded', e => {


### PR DESCRIPTION
追加したサンプルの`notify()`に余計な引数が混在していたためそれの除去