### PR TITLE
`loadJSONRouteList`で複数のルータに対応+α

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 2. [JavaScriptでルーティングをやってみる【履歴操作編】 - いろはの物置き場](https://168iroha.net/blog/article/202306260059/)
 3. [JavaScriptでルーティングをやってみる【ルート情報編】 - いろはの物置き場](https://168iroha.net/blog/article/202307210051/)
 4. [JavaScriptでルーティングをやってみる【リダイレクト・フォワード編】 - いろはの物置き場](https://168iroha.net/blog/article/202308090039/)
+4. [JavaScriptでルーティングをやってみる【実用編】 - いろはの物置き場](https://168iroha.net/blog/article/202410250132/)

--- a/src/level2/route-path.js
+++ b/src/level2/route-path.js
@@ -80,6 +80,15 @@ class RoutePath {
 		}).join('/'));
 	}
 
+	/**
+	 * ディレクトリパラメータを持つか判定する
+	 * @returns ディレクトリパラメータをもつ場合true、持たない場合false
+	 */
+	/* istanbul ignore next */
+	hasParams() {
+		return this.#path.split('/').some(token => token.startsWith(':'));
+	}
+
 	toString() {
 		return this.#path;
 	}

--- a/src/level2/router.js
+++ b/src/level2/router.js
@@ -427,6 +427,11 @@ class RouteHistory extends ARouter {
 		while (cnt++ < this.redirectionLimit) {
 			// ルート解決の実施
 			const traceRoute = this.#router.routing(nextRoute, new TraceRoute(this));
+			/* istanbul ignore next */
+			if (traceRoute.routes.length === 0) {
+				// ルート情報自体が存在しなければリダイレクトやフォワードもないため終了
+				return traceRoute;
+			}
 			const lastRoute = traceRoute.routes[traceRoute.routes.length - 1];
 
 			const to = lastRoute.l1route.body.navigate;

--- a/src/level3/routing.level3.js
+++ b/src/level3/routing.level3.js
@@ -1,9 +1,8 @@
-import { IHistoryStorage } from "../level1/history-storage.js";
 import { RouteTable as L1RouteTable } from "../level1/route-table.js";
 import { Router as L1Router } from "../level1/router.js";
 import { TraceRoute } from "../level1/trace-route.js";
 import { Route as L2Route, ResolveRoute as L2ResolveRoute } from "../level2/route.js";
-import { createTraceRouteElement, ARouter, Router, RouteHistory } from "../level2/router.js";
+import { createTraceRouteElement, ARouter as L2ARouter, Router as L2Router, RouteHistory as L2RouteHistory } from "../level2/router.js";
 
 /**
  * @template T
@@ -29,20 +28,51 @@ import { createTraceRouteElement, ARouter, Router, RouteHistory } from "../level
  * @typedef { import("../level2/router.js").InputRoute } InputRoute ルート解決などの際に引数として入力するルート情報
  */
 
+/**
+ * @template T
+ * @typedef { L2Route<T, Promise<boolean>, Promise<boolean>> } Route ルート情報クラス
+ */
+
+/**
+ * @template T
+ * @typedef { L2ResolveRoute<T, Promise<boolean>, Promise<boolean>> } ResolveRoute Router.get()などにより取得するルート情報クラス
+ */
+
+/**
+ * @template T
+ * @typedef { L2ARouter<T, Promise<boolean>, Promise<boolean>> } ARouter ルータの抽象クラス
+ */
+
+/**
+ * @template T
+ * @typedef { L2Router<T, Promise<boolean>, Promise<boolean>> } Router ルータクラス
+ */
+
+/**
+ * @template T
+ * @typedef { L2RouteHistory<T, Promise<boolean>, Promise<boolean>, Promise<boolean>, Promise<boolean>> } RouteHistory 履歴操作クラス
+ */
+
+/**
+ * @template T
+ * @typedef { L2HistoryStorage<T, Promise<boolean>, Promise<boolean>> } HistoryStorage 履歴のストレージ
+ */
+
  /**
   * @template T
   * @typedef {{
   *     description?: string;
   *     segment?: boolean;
   *     body?: T;
+  *     subroute?: JSONRoute<T>
   * }
   * &
   * ({
-  *     redirect?: InputRoute;
+  *     redirect?: { route: InputRoute; map?: Record<string, string> };
   *     forward: never;
   * } | {
   *     redirect: never;
-  *     forward?: InputRoute;
+  *     forward?: { route: InputRoute; map?: Record<string, string> };
   * })
   * &
   * ({
@@ -88,7 +118,7 @@ const { beforeEach, afterEach } = eachCallbackObj;
  * ルータについてオブザーバ
  * @template T, R1, R2
  * @param { L1Route<L1RouteBody<T, R1, R2>> | undefined } route ルート解決したルート情報
- * @param { TraceRoute<ARouter<T, R1, R2>, L2ResolveRoute<T, R1, R2>> } trace 現在までの経路
+ * @param { TraceRoute<L2ARouter<T, R1, R2>, L2ResolveRoute<T, R1, R2>> } trace 現在までの経路
  */
 function routerObserver(route, trace) {
     // リダイレクト・フォワードが設定されていれば即時終了
@@ -105,7 +135,7 @@ function routerObserver(route, trace) {
         }
     }
     {
-        const traceRoute = route.body?.route?.lifecycle?.routing?.(trace);
+        const traceRoute = route?.body?.route?.lifecycle?.routing?.(trace);
         if (traceRoute !== undefined) {
             trace = traceRoute;
         }
@@ -118,9 +148,9 @@ function routerObserver(route, trace) {
 
 /**
  * 履歴についてオブザーバ
- * @template T, R1, R2
- * @param { TraceRoute<ARouter<T, R1, R2>, L2ResolveRoute<T, R1, R2>>? } from 遷移元のルート解決の経路
- * @param { TraceRoute<ARouter<T, R1, R2>, L2ResolveRoute<T, R1, R2>>? } to 遷移先のルート解決の経路
+ * @template T
+ * @param { TraceRoute<ARouter<T>, ResolveRoute<T>>? } from 遷移元のルート解決の経路
+ * @param { TraceRoute<ARouter<T>, ResolveRoute<T>>? } to 遷移先のルート解決の経路
  */
 async function historyObserver(from, to) {
     if (await eachCallbackObj.beforeEachCallback?.(from, to) === false) {
@@ -188,41 +218,57 @@ async function historyObserver(from, to) {
 
 /**
  * ルータを作成する
- * @template T, R1, R2
- * @param { L2Route<T, R1, R2> | L2HistoryStorage<T, R1, R2> } obj ルート解決のベースとなるルート | 履歴を管理するストレージ
- * @returns { ARouter<T, R1, R2> }
+ * @template T
+ * @param { Route<T> | HistoryStorage<T> } obj ルート解決のベースとなるルート | 履歴を管理するストレージ
+ * @returns { ARouter<T> }
  */
 function createRouter(obj) {
-    /** @type { L1Router<L1RouteBody<T, R1, R2>, ARouter<T, R1, R2>, L2ResolveRoute<T, R1, R2>> } */
+    /** @type { L1Router<L1RouteBody<T, Promise<boolean>, Promise<boolean>>, ARouter<T>, ResolveRoute<T>> } */
     const l1Router = new L1Router(new L1RouteTable(), createTraceRouteElement, routerObserver);
 
     // 引数のパターンに応じたルータを返す
     if (obj instanceof L2Route) {
-        return new Router(l1Router, obj);
+        return new L2Router(l1Router, obj);
     }
     else {
-        return new RouteHistory(l1Router, obj, historyObserver, historyObserver, historyObserver);
+        return new L2RouteHistory(l1Router, obj, historyObserver, historyObserver, historyObserver, historyObserver);
     }
 }
 
 /**
  * JSON形式のルート情報をルータに登録する
- * @param { ARouter<T, R1, R2> } router ルート情報を登録するルータ
+ * @template T
+ * @param { ARouter<T> } router ルート情報を登録するルータ
  * @param { JSONRoute<T>[] } jsonRouteList JSON形式のルート情報のリスト(トポロジカルソートされる)
- * @returns { number } リダイレクト・フォワード先が存在しなくて登録されなかったルート情報の数
+ * @param { number } size jsonRouteListに対して登録する数
+ * @returns { [{ jsonRouteList: JSONRoute<T>[]; router: ARouter<T>; size: number }] } リダイレクト・フォワード先が存在しなくて登録されなかったルート情報の数に関する情報
  */
-function loadJSONRouteList(router, jsonRouteList) {
+function loadJSONRouteList(router, jsonRouteList, size = jsonRouteList.length) {
     // 登録済みのルート情報の数
     let regstered = 0;
 
-    while (jsonRouteList.length !== regstered) {
+    /** @type { [{ jsonRouteList: JSONRoute<T>[]; router: ARouter<T>; size: number }] } ルート解決結果 */
+    const ret = [];
+
+    while (size !== regstered) {
         // 現在の登録状況の退避
         const temp = regstered;
         
-        for (let i = 0; i < jsonRouteList.length - regstered;) {
+        for (let i = 0; i < size - regstered;) {
             const jsonRoute = jsonRouteList[i];
             // リダイレクト・フォワードの解決先が存在しないときはスキップする
-            if (jsonRoute.redirect !== undefined && router.get(jsonRoute.redirect) === undefined || jsonRoute.forward !== undefined && router.get(jsonRoute.forward) === undefined) {
+            const navigateRoute = (() => {
+                try {
+                    return jsonRoute.redirect !== undefined && router.routing(jsonRoute.redirect.route) || jsonRoute.forward !== undefined && router.routing(jsonRoute.forward.route);
+                }
+                catch {
+                    // ディレクトリパラメータの変換により
+                    // ディレクトリパラメータのミスマッチが生じて例外が発生する可能性があるため
+                    // リダイレクト・フォワードの解決先が存在しない扱いにする
+                    return undefined;
+                }
+            })();
+            if (navigateRoute !== false && (navigateRoute === undefined || navigateRoute.routes.length === 0 || navigateRoute.routes[navigateRoute.routes.length - 1].rest !== undefined)) {
                 ++i;
                 continue;
             }
@@ -232,28 +278,70 @@ function loadJSONRouteList(router, jsonRouteList) {
             if (jsonRoute.name !== undefined) {
                 route.path = jsonRoute.path;
             }
-            if (jsonRoute.forward !== undefined) {
-                route.forward = { route: router.get(jsonRoute.forward) };
-            }
-            if (jsonRoute.redirect !== undefined) {
-                route.redirect = { route: router.get(jsonRoute.redirect) };
+            if (navigateRoute !== false) {
+                // ↑は型推論のためのガード条件を記述
+                if (jsonRoute.forward !== undefined) {
+                    const navigate = { route: navigateRoute.routes[navigateRoute.routes.length - 1].l1route.body.route };
+                    if (jsonRoute.forward.map !== undefined) {
+                        // ディレクトリパラメータ名の対応関係からディレクトリパラメータの変換を構築する
+                        const map = jsonRoute.forward.map;
+                        navigate.map = params => Object.fromEntries(Object.entries(map).map(([to, from]) => [to, params[from]]));
+                    }
+                    route.forward = navigate;
+                }
+                if (jsonRoute.redirect !== undefined) {
+                    const navigate = { route: navigateRoute.routes[navigateRoute.routes.length - 1].l1route.body.route };
+                    if (jsonRoute.redirect.map !== undefined) {
+                        // ディレクトリパラメータ名の対応関係からディレクトリパラメータの変換を構築する
+                        const map = jsonRoute.redirect.map;
+                        navigate.map = params => Object.fromEntries(Object.entries(map).map(([to, from]) => [to, params[from]]));
+                    }
+                    route.redirect = navigate;
+                }
             }
             route.l1route.segment = jsonRoute.segment;
             route.body = jsonRoute.body;
 
+            // 別のルータを用いてルート解決する場合
+            if (jsonRoute.subroute !== undefined) {
+                const subrouter = createRouter(route);
+                ret.push(...loadJSONRouteList(subrouter, jsonRoute.subroute));
+            }
+
             // 登録済みのルート情報は後方の未登録のルート情報と入れ替える
-            jsonRouteList[i] = jsonRouteList[jsonRouteList.length - regstered - 1];
-            jsonRouteList[jsonRouteList.length - regstered - 1] = jsonRoute;
+            jsonRouteList[i] = jsonRouteList[size - regstered - 1];
+            jsonRouteList[size - regstered - 1] = jsonRoute;
             ++regstered;
         }
 
+        // 別のルータで未解決なルートを解決する
+        let subregstered = 0;
+        for (let i = 0; i < ret.length; ++i) {
+            const subret = ret[i];
+            if (subret.size !== 0) {
+                const newSubret = loadJSONRouteList(subret.router, subret.jsonRouteList, subret.size);
+                if (subret.size !== newSubret[newSubret.length - 1].size) {
+                    // 解決により減少した未解決のルートの数を記憶
+                    subregstered += subret.size - newSubret[newSubret.length - 1].size;
+                    // 最後の要素はsubretを更新したものに相当するため置き換える
+                    ret[i] = newSubret[newSubret.length - 1];
+                    if (newSubret.length > 1) {
+                        // 1番目～最後の要素-1の要素はsubret.routerのルート情報に接続されたルータに関するもの(新規生成されたルータ)のため
+                        // 単純に新規要素として追加する
+                        ret.push(...newSubret.slice(0, -1));
+                    }
+                }
+            }
+        }
+
         // 登録されなくなったら終了
-        if (regstered === temp) {
+        if (regstered === temp && subregstered === 0) {
             break;
         }
     }
 
-    return jsonRouteList.length - regstered;
+    ret.push({ jsonRouteList, router, size: size - regstered });
+    return ret;
 }
 
 export { createRouter, beforeEach, afterEach, loadJSONRouteList };


### PR DESCRIPTION
## 概要
- `loadJSONRouteList`で複数のルータに対応
  使用例は以下の通り
  ```javascript
   const storage = new MemoryHistoryStorage();
   const router = createRouter(storage);
   // ルート情報の登録
   for (const rest of loadJSONRouteList(router, routeTable)) {
       // 登録に失敗したルート情報が存在するか検査
       if (rest.size !== 0) {
           throw new Error(`解決できないルート情報が含まれている: ${JSON.stringify(rest.jsonRouteList.slice(0, rest.size))}`);
       }
   }
  ```
- レベル3機能の型の整理
- レベル2機能の`RouteHistory.routing`のバグの修正
- `RoutePath.hasParams`の追加